### PR TITLE
Prevent non-exported struct fields to be reflected

### DIFF
--- a/pkg/luareflect/reflect.go
+++ b/pkg/luareflect/reflect.go
@@ -43,6 +43,9 @@ func ToLua(L *lua.LState, data interface{}) lua.LValue {
 		t := L.NewTable()
 		for i := 0; i < typ.NumField(); i++ {
 			lk := lua.LString(typ.Field(i).Name)
+			if len(typ.Field(i).PkgPath) > 0 {
+				continue
+			}
 			lv := ToLua(L, val.Field(i).Interface())
 			t.RawSet(lk, lv)
 		}


### PR DESCRIPTION
Reflecting a non-exported field to an interface with `.Field(i).Interface()` panic.
`.Field(i).PkgPath` is empty for upper case (exported) field/method names (see https://golang.org/pkg/reflect/#StructField for more info)

Signed-off-by: Jeroen Simonetti jeroen@simonetti.nl
